### PR TITLE
Set up continuous integration & deployment with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 branches:
   except:
-  #- master
+   - gh-pages
 
 install:
  - make install-deps
@@ -20,12 +20,12 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GH_TOKEN
-  target_branch: master
+  target_branch: gh-pages
   local_dir: _site
   on:
-    branch: develop
+    branch: master
 
 env:
   global:
-    # Contains GH_TOKEN that's used in `make push-github`
-    secure:
+    # Contains GH_TOKEN that's used when pushing to gh-pages
+    secure: GCWpr5+brrs/4y60ouK5zLMcxgIgS6I+BHHxbJevJ6YbFm3NUcEQN2oukk1xf4wUedu/NEOlsXA8gasjSzd09ZkuJul30zdHAapFPhBbhci5KiMOMUE595HFQP924dYp7ltvZL8GD+1Gy2/Lr/ftGgyUlRP5j3Ki3fPe7BjentvgI/8lb2Q8YX/1JcuG6QbT8eyr7/KgSCEfH1v24YQ6Zit/OPXtMwtAVjs0oLb8OYjQ6apDbqRa+dWHqLYZ9dNWfJJkvHYuQpznOcka3gz3VdHeffB7TY8wOBCTPCzI5MeJEm0hGFwiV+2SXO1bygdQS99AkreE2pKJHgW0IvTAeID5RpBNOfgyVkrFQAgrLvPiEkVO2H70DS0LBQNbN3fUMoJoBrT2ZwjOedbxpzO0n2obNMGoSQ3Mr9pL5Tkl2oHH7FWxxbMFdtpJ69nifnqQmiKtc1+K16dIhVtNfpnW1nt7IE94GRmo1lQj2F+mamS3eJ74+f+3v8Su4AmK6PXf9KM7oATvJD3oPlk1EXyj1YbfiVOoD1excyOBN8UEThazlJhZ9AsrzfkQlFn0tEZu+JkT/KeL4XES1Rq/ygq4mfUaERiVrvPdmvJh0OR1hxYIrfkZK/R6obE7qYGB1csJ49ALtAmI90QR0wHtQZSDMkm35ZDNhzdXifBb0+J3sRA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# Based on: https://github.com/ActivityWatch/activitywatch.github.io/blob/05744092a631328f6ac05ee1bc248790d4be6593/.travis.yml
+
+dist: trusty
+
+language: python
+python:
+ - '3.6'
+
+branches:
+  except:
+  #- master
+
+install:
+ - make install-deps
+
+script:
+ - make build
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GH_TOKEN
+  target_branch: master
+  local_dir: _site
+  on:
+    branch: develop
+
+env:
+  global:
+    # Contains GH_TOKEN that's used in `make push-github`
+    secure:


### PR DESCRIPTION
 - For this to go into effect, we need to start using the `develop` branch as our default branch and use the `master` branch only as a place for builds of the website which GitHub will serve.
   - An example is [here](https://github.com/ActivityWatch/activitywatch.github.io/branches) where an identical setup is used for [activitywatch.net](http://activitywatch.net/).