### PR TITLE
MathJax support

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 ---
+<script type="text/javascript" async
+  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+</script>
 <article class="post">
 
   <header class="post-header">


### PR DESCRIPTION
It would be nice to have MathJax support. Since we already use kramdown we can use math blocks. The only thing missing is actually loading the javascript rendering MathJax.js. This can be done on a page by page basis, the following will render fine:

```markdown
<script type="text/javascript" async
  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
</script>

## The mathematics heavy section

In the equation below you see math being done

$$
\frac{a}{b} = q + \frac{r}{b}
$$
```

However I would like to simplify this or enable it globally.

In this branch I've done it by adding the js load to the default layout. It works but it could be cleaner.